### PR TITLE
A2 basic elixir

### DIFF
--- a/ex00.ex
+++ b/ex00.ex
@@ -36,7 +36,7 @@ defmodule Ex00 do
   # Write a function that increments its numeric parameter #
   ##########################################################
 
-  inc = your_anonymous_function(1)
+  inc = fn value ->value+1 end
 
   assert inc.(2)  == 3
   assert inc.(-1) == 0

--- a/ex01.ex
+++ b/ex01.ex
@@ -36,7 +36,7 @@ defmodule Ex01 do
   # Write a function that adds two numbers using fn syntax #
   ##########################################################
 
-  sum2a = your_anonymous_function(1, 2)
+  sum2a = fn num1, num2-> num1+num2 end
 
   assert sum2a.(1, 2)    == 3
   assert sum2a.(-1, 100) == 99
@@ -47,7 +47,7 @@ defmodule Ex01 do
   # Write a function that adds two numbers using & syntax  #
   ##########################################################
 
-  sum2b = your_anonymous_function(1, 2)
+  sum2b = &(&1 + &2)
 
   assert sum2b.(1, 2)    == 3
   assert sum2b.(-1, 100) == 99
@@ -60,8 +60,7 @@ defmodule Ex01 do
   # no explicit + operators in your function                          #
   #####################################################################
 
-  sum3a = your_anonymous_function(1, 2, 3)
-
+  sum3a = fn (num1, num2, num3) -> sum2a.(num1,num2)|> sum2a.(num3) end
   assert sum3a.(1, 3, 5)  == 9
   assert sum3a.(1, -3, 5) == 3
 
@@ -71,7 +70,7 @@ defmodule Ex01 do
   # Do the same using the & notation #
   ####################################
 
-  sum3b = your_anonymous_function
+  sum3b = &(sum2a.(&1, &2)|>sum2a.(&3)) 
 
   assert sum3b.(1, 3, 5)  == 9
   assert sum3b.(1, -3, 5) == 3
@@ -86,7 +85,11 @@ defmodule Ex01 do
   # function. The examples below will make this clearer :)               #
   ########################################################################
 
-  create_adder = your_anonymous_function(1)
+  create_adder = fn (num1) ->
+    fn(num2)->
+      num1+num2
+    end
+  end
 
   add_2  = create_adder.(2)
   add_99 = create_adder.(99)
@@ -94,6 +97,6 @@ defmodule Ex01 do
   assert add_2.(3)  == 5
   assert add_99.(3) == 102
 
-end
+end 
 
 

--- a/ex02.ex
+++ b/ex02.ex
@@ -30,7 +30,7 @@ defmodule Ex02 do
   # numbers, and second should be the difference                         #
   ########################################################################
 
-  list2a = your_anonymous_function(1, 2)
+  list2a = fn(num1, num2)->[num1+num2, num1-num2] end
 
   assert list2a.(1, 2)    == [ 3, -1 ]
   assert list2a.(-1, 100) == [ 99, -101 ]
@@ -41,7 +41,7 @@ defmodule Ex02 do
   # Do the same using the & syntax #
   ##################################
 
-  list2b = your_anonymous_function(1, 2)
+  list2b = &[&1+&2,&1-&2]
 
   assert list2b.(1, 2)    == [ 3, -1 ]
   assert list2b.(-1, 100) == [ 99, -101 ]
@@ -53,12 +53,19 @@ defmodule Ex02 do
   # if the first two elements of a list are equal                #
   ################################################################
 
-  first2equal = your_anonymous_function([])
+  first2equal = fn(list)-> 
+  [a, b | _rest]=list 
+    cond do
+      a==b-> true 
+      true-> false
+    end
+  end
+
 
 
   assert  first2equal.([4, 4, 5, 6, 7])
   assert !first2equal.([4, 5, 6, 7, 8])
-
 end
+ 
 
 

--- a/ex03.ex
+++ b/ex03.ex
@@ -114,9 +114,11 @@ defmodule Ex03 do
 
   """
 
-  def list_equal(a,a), do: true
-  def list_equal(_a,_b), do: false
-
+  def list_equal([_a|rest],[_a|rest2]), do: list_equal(rest,rest2)
+  def list_equal([_a|_rest],[_b|_rest2]), do: false
+  def list_equal([],[_b|_rest]), do: false
+  def list_equal([_a|_rest],[]), do: false
+  def list_equal([],[]), do: true
 
 
 

--- a/ex03.ex
+++ b/ex03.ex
@@ -114,7 +114,7 @@ defmodule Ex03 do
 
   """
 
-  def list_equal([_a|rest],[_a|rest2]), do: list_equal(rest,rest2)
+  def list_equal([a|rest],[a|rest2]), do: list_equal(rest,rest2)
   def list_equal([_a|_rest],[_b|_rest2]), do: false
   def list_equal([],[_b|_rest]), do: false
   def list_equal([_a|_rest],[]), do: false

--- a/ex03.ex
+++ b/ex03.ex
@@ -55,7 +55,15 @@ defmodule Ex03 do
 
   """
 
-  def odd_even . . . "your code"
+  def odd_even([a|rest]) do
+    cond do
+      Integer.is_odd(a)->[:odd| odd_even(rest)]
+      Integer.is_even(a)->[:even|odd_even(rest)]
+    end
+  end
+  def odd_even([]) do
+    []
+  end
 
 
   ##############################################################################
@@ -77,8 +85,13 @@ defmodule Ex03 do
 
   """
 
-  def list_contains . .. "your code"
-
+  def list_contains([a|rest],b) do
+    cond do 
+      a==b->true
+      true->list_contains(rest,b)
+    end
+  end
+  def list_contains([],_b) do false end
   ##############################################################################
   # 3.3:  5 points #
   ##################
@@ -92,7 +105,7 @@ defmodule Ex03 do
   a function that checks for the equality of two lists. You don't
   need to consider nested lists.
 
-      iex> Ex03.list_equal [ 1, 2, 3 ], [1, 2, 3]
+      iex> Ex03.list_equal [ 1, 2, 3 ], [1, 2, 3 ]
       true
       iex> Ex03.list_equal [ 1, 2, 3 ], [1, 2, 3, 4]
       false
@@ -101,7 +114,9 @@ defmodule Ex03 do
 
   """
 
-  def list_equal . . . "your code"
+  def list_equal(a,a), do: true
+  def list_equal(_a,_b), do: false
+
 
 
 
@@ -149,8 +164,31 @@ defmodule Ex03 do
   Think a little about a nice way to lay this code out.
   """
 
-  def won . . . "your code"
+  def won ({a,b,c}) do 
+    cond do
+      a==b->
+        cond do
+          b==c->true
+          true->false
+        end
+      true->false
+    end
+  end
 
+  def won({a,b,c,d,e,f,g,h,i}) do
+    cond do
+      won({a,b,c})->a
+      won({d,e,f})->d
+      won({g,h,i})->g
+      won({a,d,g})->a
+      won({b,e,h})->b
+      won({c,f,i})->c
+      won({a,e,i})->a
+      won({c,e,g})->c
+      true->false
+    end
+  end 
+    
 
   ###########################
   # IGNORE FROM HERE TO END #
@@ -161,7 +199,6 @@ defmodule Ex03 do
   def __after_compile__(_env, bytecode) do
     File.write("Elixir.Ex03.beam", bytecode)
   end
-
 end
 
 

--- a/ex04.ex
+++ b/ex04.ex
@@ -67,28 +67,22 @@ defmodule Ex04 do
   `Integer.is_odd`, and you can use the `reverse` function you defined
   above. Feel free to write helper functions if you want.
 
-      iex> Ex04.even_odd [ 1, 2, 3, 4, 5 ]
+      iex> Ex04.even_odd [1,2,3,4,5]
       { [ 2, 4],  [ 1, 3, 5 ] }
 
   Hint: you're taking a list and converting it into something else. What function
   helps you do that. And, if you use that function, what does it return? That
   return value will be the thing you have to manipulate.
   """
-  def add_if_even(num ,list) do
-    cond do
-      Integer.is_even(num)-> [num|list]
-      true->list
-    end
-  end
-
-  def add_if_odd(num ,list) do
-    cond do
-      Integer.is_odd(num)-> [num|list]
-      true->list
-    end
+  
+  def add_even_odd(num, {list1,list2}) do
+  	cond do
+  		Integer.is_odd(num)->{list1,[num|list2]}
+  		Integer.is_even(num)-> {[num|list1],list2}
+  	end
   end
   
-  def even_odd(list), do: {reduce(list,[], &add_if_even(&1,&2))|>reverse, reduce(list,[], &add_if_odd(&1,&2))|>reverse}
+  def even_odd(list), do: reduce(list|>reverse,{[],[]}, &add_even_odd(&1,&2))
 
 
 

--- a/ex04.ex
+++ b/ex04.ex
@@ -39,7 +39,7 @@ defmodule Ex04 do
       [ 1, 2, 3, 4, 5 ]
 
   """
-  def reverse . . . "your code"
+  def reverse(list),  do: reduce( list ,[], &[&1|&2]) 
 
   ##############################################################################
   # 4.2:  5 points #
@@ -55,8 +55,8 @@ defmodule Ex04 do
 
   """
 
-  def min . . . "your code"
 
+  def min([h|t]) , do: reduce([h|t], h,&(min(&1,&2)))
   ##############################################################################
   # 4.3: 10 points #
   ##################
@@ -74,8 +74,21 @@ defmodule Ex04 do
   helps you do that. And, if you use that function, what does it return? That
   return value will be the thing you have to manipulate.
   """
+  def add_if_even(num ,list) do
+    cond do
+      Integer.is_even(num)-> [num|list]
+      true->list
+    end
+  end
 
-  def even_odd . . . "your code"
+  def add_if_odd(num ,list) do
+    cond do
+      Integer.is_odd(num)-> [num|list]
+      true->list
+    end
+  end
+  
+  def even_odd(list), do: {reduce(list,[], &add_if_even(&1,&2))|>reverse, reduce(list,[], &add_if_odd(&1,&2))|>reverse}
 
 
 


### PR DESCRIPTION
Name: Arslan Memon Id: 45111083

Note: 
when I ran this
Ex04.even_odd [2, 37, 4, 10, 20, 35, 38, 11,12] the return value I got was {[2, 4, 10, 20, 38, 12], '%#\v'}

I'm not sure why it didn't work for that case, but it passed the other tests I did and the one that was supposed to be performed. I'd appreciate if you could explain why it gives  '%#\v' instead of the odd values in a  list. Thanks!
